### PR TITLE
feat: Add device registry support for entities (#33)

### DIFF
--- a/custom_components/einskomma5grad/api/system.py
+++ b/custom_components/einskomma5grad/api/system.py
@@ -1,10 +1,13 @@
 import datetime
+import logging
 
 import requests
 
 from .client import Client, REQUEST_TIMEOUT
 from .error import RequestError
 from .ev_charger import EVCharger
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class System:
@@ -14,6 +17,34 @@ class System:
 
     def id(self) -> str:
         return self.data["id"]
+
+    def get_status_and_assets(self) -> dict | None:
+        """Fetch site status and assets. Returns None on any failure."""
+        try:
+            res = requests.get(
+                url=self.client.HEARTBEAT_API
+                + "/api/v2/sites/"
+                + self.id()
+                + "/status-and-assets",
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer " + self.client.get_token(),
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.exceptions.RequestException:
+            _LOGGER.debug("Failed to fetch status-and-assets for system %s", self.id())
+            return None
+
+        if res.status_code != 200:
+            _LOGGER.debug(
+                "status-and-assets returned %s for system %s",
+                res.status_code,
+                self.id(),
+            )
+            return None
+
+        return res.json()
 
     def get_live_overview(self):
         try:

--- a/custom_components/einskomma5grad/battery_power_sensor.py
+++ b/custom_components/einskomma5grad/battery_power_sensor.py
@@ -5,10 +5,12 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfPower
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 class BatteryPowerInSensor(CoordinatorEntity, SensorEntity):
     """Representation of Battery Power In Sensor."""
@@ -62,6 +64,10 @@ class BatteryPowerInSensor(CoordinatorEntity, SensorEntity):
     def state_class(self) -> SensorStateClass | str | None:
         """Return the state class of the sensor."""
         return SensorStateClass.MEASUREMENT
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.HYBRID)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -125,6 +131,10 @@ class BatteryPowerOutSensor(CoordinatorEntity, SensorEntity):
     def state_class(self) -> SensorStateClass | str | None:
         """Return the state class of the sensor."""
         return SensorStateClass.MEASUREMENT
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.HYBRID)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/einskomma5grad/battery_soc_sensor.py
+++ b/custom_components/einskomma5grad/battery_soc_sensor.py
@@ -5,10 +5,12 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 
 class BatteryStateOfChargeSensor(CoordinatorEntity, SensorEntity):
@@ -88,6 +90,10 @@ class BatteryStateOfChargeSensor(CoordinatorEntity, SensorEntity):
     def state_class(self) -> SensorStateClass | str | None:
         """Return the state class of the sensor."""
         return SensorStateClass.MEASUREMENT
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.HYBRID)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/einskomma5grad/const.py
+++ b/custom_components/einskomma5grad/const.py
@@ -1,5 +1,7 @@
 """Constants for the 1KOMMA5GRAD integration."""
 
+from enum import StrEnum
+
 DEFAULT_SCAN_INTERVAL = 60
 
 # Minimum and maximum allowed scan interval (seconds)
@@ -9,3 +11,12 @@ MAX_SCAN_INTERVAL = 3600
 DOMAIN = "einskomma5grad"
 
 CURRENCY_ICON = "mdi:cash"
+
+
+class DeviceType(StrEnum):
+    """Device types for mapping entities to HA device registry entries."""
+
+    GATEWAY = "gateway"
+    HYBRID = "hybrid"
+    EV_CHARGER = "ev_charger"
+    HEAT_PUMP = "heat_pump"

--- a/custom_components/einskomma5grad/coordinator.py
+++ b/custom_components/einskomma5grad/coordinator.py
@@ -29,6 +29,30 @@ class EVData:
     system_id: str | None
 
 @dataclass
+class AssetInfo:
+    """Individual device asset info from status-and-assets endpoint."""
+    asset_id: str
+    asset_type: str  # EV_CHARGER, HYBRID, HEAT_PUMP, METER
+    manufacturer: str | None
+    model: str | None
+    serial_number: str | None
+    name: str | None
+
+@dataclass
+class GatewayInfo:
+    """Gateway device info."""
+    gateway_id: str
+    serial_number: str
+    system_name: str
+    system_id: str
+
+@dataclass
+class DeviceData:
+    """Holds all device registry info for a system."""
+    gateway: GatewayInfo | None = None
+    assets_by_type: dict[str, AssetInfo] | None = None
+
+@dataclass
 class SystemsData:
     """Class to hold api data."""
 
@@ -43,6 +67,8 @@ class SystemsData:
     ev_data: dict[str, EVData] = None
 
     ev_charging_modes: dict[str, list[str]] = None
+
+    device_data: dict[str, DeviceData] | None = None
 
 class Coordinator(DataUpdateCoordinator):
     """1KOMMA5GRAD coordinator."""
@@ -97,6 +123,7 @@ class Coordinator(DataUpdateCoordinator):
             live_overview = {}
             ev_data = {}
             ev_charging_modes = {}
+            device_data = {}
             for system in systems:
                 prices[system.id()] = await self.hass.async_add_executor_job(
                     system.get_prices,
@@ -135,6 +162,9 @@ class Coordinator(DataUpdateCoordinator):
                     system.get_displayed_ev_charging_modes,
                 )
 
+                # Fetch device info (gateway + assets) — purely optional
+                device_data[system.id()] = await self._fetch_device_data(system)
+
             # What is returned here is stored in self.data by the DataUpdateCoordinator
             return SystemsData(
                 systems=systems,
@@ -143,6 +173,7 @@ class Coordinator(DataUpdateCoordinator):
                 ems_settings=ems_settings,
                 ev_data=ev_data,
                 ev_charging_modes=ev_charging_modes,
+                device_data=device_data,
             )
         except ApiError as err:
             raise UpdateFailed(err) from err
@@ -192,6 +223,57 @@ class Coordinator(DataUpdateCoordinator):
         """Enable EMS auto mode."""
         systems = Systems(self.api)
         systems.get_system(system_id).set_ems_mode(enable)
+
+    def get_device_data_by_id(self, system_id: str) -> DeviceData | None:
+        """Return device data by system id."""
+        if self.data.device_data is None:
+            return None
+        return self.data.device_data.get(system_id)
+
+    async def _fetch_device_data(self, system: System) -> DeviceData:
+        """Fetch gateway and asset device info. Never raises."""
+        result = DeviceData()
+
+        # Gateway info from existing system data
+        try:
+            gateways = system.data.get("deviceGateways", [])
+            if gateways:
+                gw = gateways[0]
+                serial = gw.get("serialNumber")
+                if serial:
+                    result.gateway = GatewayInfo(
+                        gateway_id=gw.get("id", ""),
+                        serial_number=serial,
+                        system_name=system.data.get("systemName", ""),
+                        system_id=system.id(),
+                    )
+        except Exception:
+            _LOGGER.debug("Could not extract gateway info for system %s", system.id())
+
+        # Assets from status-and-assets endpoint
+        try:
+            response = await self.hass.async_add_executor_job(
+                system.get_status_and_assets,
+            )
+            if response and "assets" in response:
+                assets_by_type = {}
+                for asset in response["assets"]:
+                    asset_type = asset.get("type")
+                    if not asset_type:
+                        continue
+                    assets_by_type[asset_type] = AssetInfo(
+                        asset_id=asset.get("id", ""),
+                        asset_type=asset_type,
+                        manufacturer=asset.get("manufacturer"),
+                        model=asset.get("model"),
+                        serial_number=asset.get("serialnumber"),
+                        name=asset.get("name"),
+                    )
+                result.assets_by_type = assets_by_type
+        except Exception:
+            _LOGGER.debug("Could not fetch assets for system %s", system.id())
+
+        return result
 
     def get_live_data_by_id(self, system_id: str) -> dict | None:
         """Return prices by system id."""

--- a/custom_components/einskomma5grad/device_info.py
+++ b/custom_components/einskomma5grad/device_info.py
@@ -1,0 +1,69 @@
+"""Helpers for building DeviceInfo from coordinator device data."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN, DeviceType
+from .coordinator import Coordinator, DeviceData
+
+# Maps our DeviceType enum to the API's asset type strings
+_DEVICE_TYPE_TO_ASSET: dict[DeviceType, tuple[str, str]] = {
+    DeviceType.HYBRID: ("HYBRID", "Inverter / Battery"),
+    DeviceType.EV_CHARGER: ("EV_CHARGER", "EV Charger"),
+    DeviceType.HEAT_PUMP: ("HEAT_PUMP", "Heat Pump"),
+}
+
+
+def _gateway_device_info(device_data: DeviceData) -> DeviceInfo | None:
+    """Build DeviceInfo for the Heartbeat gateway."""
+    if device_data is None or device_data.gateway is None:
+        return None
+    gw = device_data.gateway
+    return DeviceInfo(
+        identifiers={(DOMAIN, gw.serial_number)},
+        name=f"Heartbeat {gw.system_name}" if gw.system_name else "Heartbeat",
+        manufacturer="1KOMMA5\u00b0",
+        model="Heartbeat",
+        serial_number=gw.serial_number,
+    )
+
+
+def _asset_device_info(
+    device_data: DeviceData, asset_type: str, fallback_name: str
+) -> DeviceInfo | None:
+    """Build DeviceInfo for a specific asset type (HYBRID, EV_CHARGER, HEAT_PUMP, etc.)."""
+    if device_data is None or device_data.assets_by_type is None:
+        return None
+    asset = device_data.assets_by_type.get(asset_type)
+    if asset is None:
+        return None
+    identifier = asset.serial_number or asset.asset_id
+    if not identifier:
+        return None
+    via = None
+    if device_data.gateway:
+        via = (DOMAIN, device_data.gateway.serial_number)
+    return DeviceInfo(
+        identifiers={(DOMAIN, identifier)},
+        name=asset.model or asset.name or fallback_name,
+        manufacturer=asset.manufacturer,
+        model=asset.model,
+        serial_number=asset.serial_number,
+        via_device=via,
+    )
+
+
+def get_device_info(
+    coordinator: Coordinator, system_id: str, device_type: DeviceType | None
+) -> DeviceInfo | None:
+    """Return DeviceInfo for the given device_type, or None if unavailable."""
+    if device_type is None:
+        return None
+    device_data = coordinator.get_device_data_by_id(system_id)
+    if device_data is None:
+        return None
+    if device_type == DeviceType.GATEWAY:
+        return _gateway_device_info(device_data)
+    mapping = _DEVICE_TYPE_TO_ASSET.get(device_type)
+    if mapping:
+        return _asset_device_info(device_data, mapping[0], mapping[1])
+    return None

--- a/custom_components/einskomma5grad/energy_sensor.py
+++ b/custom_components/einskomma5grad/energy_sensor.py
@@ -3,21 +3,24 @@ from datetime import datetime, UTC
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 class EnergySensor(CoordinatorEntity, SensorEntity):
     """Sensor to track the energy consumed or produced by the referenced power sensor."""
 
-    def __init__(self, coordinator: Coordinator, system_id: str, power_sensor: SensorEntity, direction: str, name: str) -> None:
+    def __init__(self, coordinator: Coordinator, system_id: str, power_sensor: SensorEntity, direction: str, name: str, device_type: DeviceType | None = None) -> None:
         """Initalize the sensor."""
         super().__init__(coordinator)
         self._system_id = system_id
         self._power_sensor = power_sensor
         self._direction = direction
         self._name = name
+        self._device_type = device_type
         self._last_update = None
         self._energy = 0.0  # Accumulated energy in kWh
 
@@ -52,6 +55,10 @@ class EnergySensor(CoordinatorEntity, SensorEntity):
     def state_class(self) -> SensorStateClass | str | None:
         """Returns the state class of the sensor."""
         return SensorStateClass.TOTAL_INCREASING
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, self._device_type)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/einskomma5grad/ev_charging_mode.py
+++ b/custom_components/einskomma5grad/ev_charging_mode.py
@@ -2,10 +2,12 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +56,10 @@ class EVChargingModeSelect(CoordinatorEntity, SelectEntity):
     def name(self) -> str:
         """Return the name of the select entity."""
         return f"EV Charging Mode {self._ev_name}"
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.EV_CHARGER)
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/einskomma5grad/ev_current_soc.py
+++ b/custom_components/einskomma5grad/ev_current_soc.py
@@ -3,10 +3,12 @@ import logging
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +74,10 @@ class EVCurrentStateOfCharge(CoordinatorEntity, NumberEntity):
     def name(self) -> str:
         """Return the name of the EV SoC entity."""
         return f"EV Current State of Charge {self._ev_name}"
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.EV_CHARGER)
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/einskomma5grad/sensor.py
+++ b/custom_components/einskomma5grad/sensor.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .energy_sensor import EnergySensor
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
 from .sensor_electricity_price import ElectricityPriceSensor
 from .sensor_power_generic import GenericPowerSensor
@@ -39,6 +39,7 @@ async def async_setup_entry(
             icon="mdi:transmission-tower-export",
             system_id=system.id(),
             name="Grid Feed Out",
+            device_type=DeviceType.GATEWAY,
         )
         sensors.append(grid_feed_out_power_sensor)
         sensors.append(
@@ -47,7 +48,8 @@ async def async_setup_entry(
                 system_id=system.id(),
                 power_sensor=grid_feed_out_power_sensor,
                 name="Grid Feed",
-                direction="out"
+                direction="out",
+                device_type=DeviceType.GATEWAY,
             )
         )
 
@@ -58,6 +60,7 @@ async def async_setup_entry(
             key="gridFeedIn",
             system_id=system.id(),
             name="Grid Feed In",
+            device_type=DeviceType.GATEWAY,
         )
         sensors.append(grid_feed_in_power_sensor)
         sensors.append(
@@ -66,7 +69,8 @@ async def async_setup_entry(
                 system_id=system.id(),
                 power_sensor=grid_feed_in_power_sensor,
                 name="Grid Feed",
-                direction="in"
+                direction="in",
+                device_type=DeviceType.GATEWAY,
             )
         )
 
@@ -77,6 +81,7 @@ async def async_setup_entry(
             key="grid",
             system_id=system.id(),
             name="Grid Feed",
+            device_type=DeviceType.GATEWAY,
         )
         sensors.append(grid_feed_total_sensor)
 
@@ -87,6 +92,7 @@ async def async_setup_entry(
             key="consumption",
             system_id=system.id(),
             name="Consumption",
+            device_type=DeviceType.GATEWAY,
         )
         sensors.append(consumption_total_power_sensor)
 
@@ -97,6 +103,7 @@ async def async_setup_entry(
             key="production",
             system_id=system.id(),
             name="Solar Production",
+            device_type=DeviceType.GATEWAY,
         )
         sensors.append(solar_power_production_sensor)
         sensors.append(
@@ -105,7 +112,8 @@ async def async_setup_entry(
                 system_id=system.id(),
                 power_sensor=solar_power_production_sensor,
                 name="Solar",
-                direction="production"
+                direction="production",
+                device_type=DeviceType.GATEWAY,
             )
         )
 
@@ -116,6 +124,7 @@ async def async_setup_entry(
             key="evChargersAggregated",
             system_id=system.id(),
             name="EV Chargers Aggregated",
+            device_type=DeviceType.EV_CHARGER,
         )
         sensors.append(ev_chargers_power_sensor)
         sensors.append(
@@ -124,7 +133,8 @@ async def async_setup_entry(
                 system_id=system.id(),
                 power_sensor=ev_chargers_power_sensor,
                 name="EV Chargers",
-                direction="consumption"
+                direction="consumption",
+                device_type=DeviceType.EV_CHARGER,
             )
         )
 
@@ -135,6 +145,7 @@ async def async_setup_entry(
             key="heatPumpsAggregated",
             system_id=system.id(),
             name="Heat Pumps Aggregated",
+            device_type=DeviceType.HEAT_PUMP,
         )
         sensors.append(heat_pumps_power_sensor)
         sensors.append(
@@ -143,7 +154,8 @@ async def async_setup_entry(
                 system_id=system.id(),
                 power_sensor=heat_pumps_power_sensor,
                 name="Heat Pumps",
-                direction="consumption"
+                direction="consumption",
+                device_type=DeviceType.HEAT_PUMP,
             )
         )
 
@@ -164,6 +176,7 @@ async def async_setup_entry(
                 power_sensor=battery_power_in_sensor,
                 name="Battery",
                 direction="in",
+                device_type=DeviceType.HYBRID,
             )
         )
 
@@ -176,7 +189,8 @@ async def async_setup_entry(
                 system_id=system.id(),
                 power_sensor=battery_power_out_sensor,
                 name="Battery",
-                direction="out"
+                direction="out",
+                device_type=DeviceType.HYBRID,
             )
         )
 

--- a/custom_components/einskomma5grad/sensor_electricity_price.py
+++ b/custom_components/einskomma5grad/sensor_electricity_price.py
@@ -5,11 +5,13 @@ from zoneinfo import ZoneInfo
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import CURRENCY_ICON, DOMAIN
+from .const import CURRENCY_ICON, DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 # The 1KOMMA5° API returns timeseries keys labeled with "Z" suffix but
 # they are actually in CET (UTC+1 fixed, no DST), following the European
@@ -72,6 +74,10 @@ class ElectricityPriceSensor(CoordinatorEntity, SensorEntity):
     def device_class(self):
         """Return the device class of the sensor."""
         return UnitOfEnergy.KILO_WATT_HOUR
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.GATEWAY)
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/einskomma5grad/sensor_power_generic.py
+++ b/custom_components/einskomma5grad/sensor_power_generic.py
@@ -5,17 +5,20 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfPower
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 
 class GenericPowerSensor(CoordinatorEntity, SensorEntity):
     """Representation of Generic Power Sensor."""
 
     def __init__(
-        self, coordinator: Coordinator, system_id: str, key: str, name: str, icon: str
+        self, coordinator: Coordinator, system_id: str, key: str, name: str, icon: str,
+        device_type: DeviceType | None = None,
     ) -> None:
         """Initialise sensor."""
         super().__init__(coordinator)
@@ -24,6 +27,7 @@ class GenericPowerSensor(CoordinatorEntity, SensorEntity):
         self._key = key
         self._name = name
         self._icon = icon
+        self._device_type = device_type
         self._live_data = {}
 
     @property
@@ -81,6 +85,10 @@ class GenericPowerSensor(CoordinatorEntity, SensorEntity):
     def state_class(self) -> SensorStateClass | str | None:
         """Return the state class of the sensor."""
         return SensorStateClass.MEASUREMENT
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, self._device_type)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/einskomma5grad/switch_ems.py
+++ b/custom_components/einskomma5grad/switch_ems.py
@@ -1,9 +1,11 @@
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .coordinator import Coordinator
+from .device_info import get_device_info
 
 
 class EmsSwitch(CoordinatorEntity, SwitchEntity):
@@ -41,6 +43,10 @@ class EmsSwitch(CoordinatorEntity, SwitchEntity):
     def available(self) -> bool:
         """Return False when EMS settings are not available."""
         return self._enabled is not None
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return get_device_info(self.coordinator, self._system_id, DeviceType.GATEWAY)
 
     @property
     def device_class(self) -> SwitchDeviceClass | None:

--- a/custom_components/einskomma5grad/test/mocks/GET_sites_id_status-and-assets.json
+++ b/custom_components/einskomma5grad/test/mocks/GET_sites_id_status-and-assets.json
@@ -1,0 +1,65 @@
+{
+  "status": "CONNECTED",
+  "assets": [
+    {
+      "id": "00000000-0000-0000-0000-000000000010",
+      "type": "EV_CHARGER",
+      "empType": "GRIDX",
+      "name": "Wallbox",
+      "connectionStatus": {
+        "status": "CONNECTED"
+      },
+      "manufacturer": "Mennekes",
+      "model": "AMTRON Compact 2.0S 11kW",
+      "serialnumber": "SN-EV-000001",
+      "firmware": "2023.21.11024-20",
+      "network": {
+        "address": "/dev/ttyAMA0"
+      }
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000011",
+      "type": "HYBRID",
+      "empType": "GRIDX",
+      "connectionStatus": {
+        "status": "CONNECTED"
+      },
+      "manufacturer": "Sungrow",
+      "model": "SH8.0RT-V112",
+      "serialnumber": "SN-HY-000001",
+      "firmware": "ARM_SAPPHIRE-H_V11_V01_B",
+      "network": {
+        "address": "10.0.0.1"
+      }
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000012",
+      "type": "HEAT_PUMP",
+      "empType": "GRIDX",
+      "connectionStatus": {
+        "status": "DISCONNECTED"
+      },
+      "manufacturer": "Vaillant",
+      "model": "VR940",
+      "serialnumber": "SN-HP-000001",
+      "network": {
+        "address": "wss://VR940.local:12480/ship/"
+      },
+      "heatPumpMeterType": "SEPARATE"
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000013",
+      "type": "METER",
+      "empType": "GRIDX",
+      "connectionStatus": {
+        "status": "CONNECTED"
+      },
+      "manufacturer": "Chint",
+      "model": "DTSU666",
+      "serialnumber": "SN-MT-000001",
+      "network": {
+        "address": "10.0.0.1"
+      }
+    }
+  ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,12 @@ def mock_api():
         "ev_modes": load_mock(
             "GET_sites_id_assets_evs_displayed-ev-charging-modes.json"
         ),
+        "status_and_assets": load_mock("GET_sites_id_status-and-assets.json"),
     }
 
     def get_router(url, **kwargs):
+        if "status-and-assets" in url:
+            return _make_response(mock_data["status_and_assets"])
         if "/api/v2/systems" in url:
             # Distinguish list vs single system: /api/v2/systems vs /api/v2/systems/{id}
             path = url.split("/api/v2/systems")[1]

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -1,0 +1,178 @@
+"""Tests for device registry integration."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .conftest import SYSTEM_ID
+
+
+@pytest.mark.asyncio
+async def test_gateway_device_created(
+    hass: HomeAssistant, setup_integration
+):
+    """Test that a Heartbeat gateway device is created."""
+    registry = dr.async_get(hass)
+    device = registry.async_get_device(
+        identifiers={("einskomma5grad", "I032-002-000-000-068-P-X")}
+    )
+    assert device is not None
+    assert device.manufacturer == "1KOMMA5\u00b0"
+    assert device.model == "Heartbeat"
+    assert device.serial_number == "I032-002-000-000-068-P-X"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_device_created(
+    hass: HomeAssistant, setup_integration
+):
+    """Test that a HYBRID (inverter/battery) device is created."""
+    registry = dr.async_get(hass)
+    device = registry.async_get_device(
+        identifiers={("einskomma5grad", "SN-HY-000001")}
+    )
+    assert device is not None
+    assert device.manufacturer == "Sungrow"
+    assert device.model == "SH8.0RT-V112"
+
+
+@pytest.mark.asyncio
+async def test_ev_charger_device_created(
+    hass: HomeAssistant, setup_integration
+):
+    """Test that an EV_CHARGER device is created."""
+    registry = dr.async_get(hass)
+    device = registry.async_get_device(
+        identifiers={("einskomma5grad", "SN-EV-000001")}
+    )
+    assert device is not None
+    assert device.manufacturer == "Mennekes"
+    assert device.model == "AMTRON Compact 2.0S 11kW"
+    assert device.name == "AMTRON Compact 2.0S 11kW"
+
+
+@pytest.mark.asyncio
+async def test_heat_pump_device_created(
+    hass: HomeAssistant, setup_integration
+):
+    """Test that a HEAT_PUMP device is created."""
+    registry = dr.async_get(hass)
+    device = registry.async_get_device(
+        identifiers={("einskomma5grad", "SN-HP-000001")}
+    )
+    assert device is not None
+    assert device.manufacturer == "Vaillant"
+    assert device.model == "VR940"
+
+
+@pytest.mark.asyncio
+async def test_child_devices_linked_via_gateway(
+    hass: HomeAssistant, setup_integration
+):
+    """Test that asset devices are linked to the gateway via via_device."""
+    registry = dr.async_get(hass)
+    gateway = registry.async_get_device(
+        identifiers={("einskomma5grad", "I032-002-000-000-068-P-X")}
+    )
+    hybrid = registry.async_get_device(
+        identifiers={("einskomma5grad", "SN-HY-000001")}
+    )
+    assert gateway is not None
+    assert hybrid is not None
+    assert hybrid.via_device_id == gateway.id
+
+
+@pytest.mark.asyncio
+async def test_entities_still_work_without_assets(
+    hass: HomeAssistant, mock_config_entry, mock_api, enable_custom_integrations
+):
+    """Test that entities work fine when status-and-assets returns None."""
+    # Patch get_status_and_assets to return None (simulating API failure)
+    with patch(
+        "custom_components.einskomma5grad.api.system.System.get_status_and_assets",
+        return_value=None,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from custom_components.einskomma5grad.const import DOMAIN
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id].coordinator
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    # Entities should still exist
+    state = hass.states.get(f"sensor.battery_in_power_{SYSTEM_ID}".replace("-", "_"))
+    assert state is not None
+
+    # No asset devices should be created
+    registry = dr.async_get(hass)
+    hybrid = registry.async_get_device(
+        identifiers={("einskomma5grad", "SN-HY-000001")}
+    )
+    assert hybrid is None
+
+
+@pytest.mark.asyncio
+async def test_entities_still_work_without_gateway(
+    hass: HomeAssistant, mock_config_entry, mock_api, enable_custom_integrations
+):
+    """Test that entities work when system has no deviceGateways."""
+    # Modify mock to remove deviceGateways
+    original_systems = mock_api["data"]["systems"]
+    modified = json.loads(json.dumps(original_systems))
+    modified["data"][0]["deviceGateways"] = []
+
+    def get_router_no_gw(url, **kwargs):
+        if "status-and-assets" in url:
+            from tests.conftest import _make_response
+            return _make_response(mock_api["data"]["status_and_assets"])
+        if "/api/v2/systems" in url:
+            from tests.conftest import _make_response
+            path = url.split("/api/v2/systems")[1]
+            if path and path != "/":
+                return _make_response(modified["data"][0])
+            return _make_response(modified)
+        # Fall through to existing router for other URLs
+        from tests.conftest import _make_response
+        if "live-overview" in url:
+            return _make_response(mock_api["data"]["live_overview"])
+        if "market-prices" in url:
+            return _make_response(mock_api["data"]["prices"])
+        if "get-settings" in url:
+            return _make_response(mock_api["data"]["ems_settings"])
+        if "displayed-ev-charging-modes" in url:
+            return _make_response(mock_api["data"]["ev_modes"])
+        if "/devices/evs" in url:
+            return _make_response(mock_api["data"]["ev_chargers"])
+        raise ValueError(f"Unexpected GET URL: {url}")
+
+    with patch(
+        "custom_components.einskomma5grad.api.systems.requests.get",
+        side_effect=get_router_no_gw,
+    ), patch(
+        "custom_components.einskomma5grad.api.system.requests.get",
+        side_effect=get_router_no_gw,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from custom_components.einskomma5grad.const import DOMAIN
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id].coordinator
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    # Entities should still exist
+    state = hass.states.get(f"sensor.electricity_price_{SYSTEM_ID}".replace("-", "_"))
+    assert state is not None
+
+    # Gateway device should NOT be created
+    registry = dr.async_get(hass)
+    gateway = registry.async_get_device(
+        identifiers={("einskomma5grad", "I032-002-000-000-068-P-X")}
+    )
+    assert gateway is None


### PR DESCRIPTION
Entities are now grouped under proper HA devices (Gateway, Inverter/Battery, EV Charger, Heat Pump) using the status-and-assets API endpoint. Gracefully degrades when device data is unavailable — entities continue to work without device assignment.